### PR TITLE
Fix router import path

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 # main.py
 from fastapi import FastAPI
-from app.api.router import router
+from app.api.v1.router import router
 from app.core.lifecycle import startup, shutdown
 
 app = FastAPI(title="TaskRouter AI")


### PR DESCRIPTION
## Summary
- fix fastapi router import path in main app entry

## Testing
- `pytest -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6843d33fe13c8332b2dd1bed38b9ba91