### PR TITLE
Pin dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 # requirements.txt
-fastapi
-uvicorn[standard]
-asyncpg
-redis
-pydantic
-python-dotenv
-httpx
+fastapi==0.110.0
+uvicorn[standard]==0.23.2
+asyncpg==0.29.0
+redis==5.0.4
+pydantic==2.6.4
+python-dotenv==1.0.1
+aiohttp==3.9.5
+httpx==0.24.1


### PR DESCRIPTION
## Summary
- pin package versions in requirements
- add aiohttp dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6843dc17c4188332b2685271422e7454