### PR TITLE
Add env example and gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# .env 
+# .env example
 DATABASE_URL=postgresql://user:pass@db:5432/taskrouter
 REDIS_URL=redis://redis:6379
 GEN_API_KEY=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/


### PR DESCRIPTION
## Summary
- sanitize `.env` and point to `.env.example`
- ignore `.env`
- include example environment configuration

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6843eab5912483328c42d1b9331533a0